### PR TITLE
Add cfn-python-lint Test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,47 @@
-language: shell
+language: bash
+
 env:
   global:
     - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - SEGFAULT_SIGNALS=all
 
-addons:
-  # apt:
-  #   sources:
-  #     - debian-sid    # Grab ShellCheck from the Debian repo
-  #   packages:
-  #     - shellcheck
-
-matrix:
+jobs:
   include:
-    - env:
+    - stage: test
+      name: "Shell Syntax-Check"
+      env:
         - TESTENV=shellcheck
         - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.sh' -type f -print0 | xargs -0 -n1 -t shellcheck"
         - SHELLCHECK_OPTS="-s bash"
-    - env:
+      before_install:
+        - echo $TESTCOMMAND
+        - shellcheck --version
+    - stage: test
+      name: "Template JSON Syntax-Check"
+      env:
         - TESTENV=json-tool
         - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.json' -type f -print0 | xargs -0 -n1 -I {} -t jq --exit-status . {} > /dev/null"
-
-before_install:
-  - echo $TESTCOMMAND
-  - shellcheck --version
-
-install:
-  # Download json parser
-  - curl -sO http://stedolan.github.io/jq/download/linux64/jq
-  - chmod +x $PWD/jq
+      install:
+        # Download json parser
+        - curl -sO http://stedolan.github.io/jq/download/linux64/jq
+        - chmod +x $PWD/jq
+    - stage: test
+      name: "Template CFn Syntax-Check"
+      language: python
+      python: 3.6
+      env:
+        - TESTENV=cfn-lint
+        # E1029: Because it chokes on BASH vars in 'content' blocks
+        # E2015: Because can't identify why it's failing on the test (relevant content is valid)
+        - TESTCOMMAND="find $TRAVIS_BUILD_DIR -name '*.json' -type f -print0 | xargs -0 -n1 -I {} -t cfn-lint -i E1029,E2015 -t {} > /dev/null"
+      install:
+        - pip install cfn-lint
 
 script:
   - bash -c "$TESTCOMMAND"
+
+stages:
+  - test
 
 notifications:
   email:

--- a/Templates/make_artifactory-EE_EC2-node.tmplt.json
+++ b/Templates/make_artifactory-EE_EC2-node.tmplt.json
@@ -16,11 +16,6 @@
         { "Fn::Equals": [ { "Ref": "PrivateIp" }, "" ] }
       ]
     },
-    "HaveAkas": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "AkaList" }, "" ] }
-      ]
-    },
     "InstallCloudWatchAgent": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "CloudWatchAgentUrl" }, "" ] }
@@ -201,7 +196,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "ArtifactoryAppHome": {
       "AllowedPattern": "^/.*$|^$",
@@ -1332,7 +1327,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "DeleteOnTermination": "true",
+              "DeleteOnTermination": true,
               "VolumeSize": { "Ref": "RootVolumeSize" },
               "VolumeType": "gp2"
             }
@@ -1359,8 +1354,8 @@
             "AssociatePublicIpAddress": {
               "Fn::If": [
                 "AssignPublicIp",
-                "true",
-                "false"
+                true,
+                false
               ]
             },
             "DeviceIndex": "0",

--- a/Templates/make_artifactory-EE_S3-buckets.tmplt.json
+++ b/Templates/make_artifactory-EE_S3-buckets.tmplt.json
@@ -169,7 +169,7 @@
                   "Format": "CSV",
                   "Prefix": "StorageReporting/Inventory"
                 },
-                "Enabled": "true",
+                "Enabled": true,
                 "IncludedObjectVersions": "Current",
                 "Prefix": "Backups/",
                 "ScheduleFrequency": "Weekly"
@@ -243,7 +243,7 @@
                   "Format": "CSV",
                   "Prefix": "StorageReporting/Inventory"
                 },
-                "Enabled": "true",
+                "Enabled": true,
                 "IncludedObjectVersions": "Current",
                 "Prefix": "Shards/",
                 "ScheduleFrequency": "Weekly"

--- a/Templates/make_artifactory-PRO_EC2-node.tmplt.json
+++ b/Templates/make_artifactory-PRO_EC2-node.tmplt.json
@@ -11,11 +11,6 @@
         { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] }
       ]
     },
-    "HaveAkas": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "AkaList" }, "" ] }
-      ]
-    },
     "NotGenFive": {
       "Fn::Not": [
         {
@@ -131,11 +126,9 @@
           },
           "Parameters": [
             "S3BackupBucket",
-            "AppVolumeDevice",
             "AppVolumeMountPath",
             "AppVolumeSize",
             "AppVolumeType",
-            "BackupVolumeDevice",
             "BackupVolumeMountPath",
             "BackupVolumeSize",
             "BackupVolumeType"
@@ -181,16 +174,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
-    },
-    "AppVolumeDevice": {
-      "AllowedValues": [
-        "false",
-        "true"
-      ],
-      "Default": "false",
-      "Description": "(Vestigial) Whether to use an EBS-based backup-staging location",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "AppVolumeMountPath": {
       "AllowedPattern": "/.*",
@@ -272,15 +256,6 @@
     "ArtifactoryRpm": {
       "Default": "jfrog-artifactory-pro",
       "Description": "Name of the Artifactory installation-RPM.",
-      "Type": "String"
-    },
-    "BackupVolumeDevice": {
-      "AllowedValues": [
-        "false",
-        "true"
-      ],
-      "Default": "false",
-      "Description": "(Vestigial) Whether to use an EBS-based backup-staging location",
       "Type": "String"
     },
     "BackupVolumeMountPath": {
@@ -991,7 +966,7 @@
           {
             "DeviceName": "/dev/sda1",
             "Ebs": {
-              "DeleteOnTermination": "true",
+              "DeleteOnTermination": true,
               "VolumeSize" : { "Ref" : "RootVolumeSize" },
               "VolumeType": "gp2"
             }
@@ -1023,7 +998,7 @@
                 "Ebs": {
                   "VolumeSize" : { "Ref" : "AppVolumeSize" },
                   "VolumeType" : { "Ref" : "AppVolumeType" },
-                  "DeleteOnTermination" : "true"
+                  "DeleteOnTermination" : true
                 }
               }
             ]
@@ -1055,7 +1030,7 @@
                 "Ebs": {
                   "VolumeSize" : { "Ref" : "BackupVolumeSize" },
                   "VolumeType" : { "Ref" : "BackupVolumeType" },
-                  "DeleteOnTermination" : "true"
+                  "DeleteOnTermination" : true
                 }
               }
             ]
@@ -1076,8 +1051,8 @@
             "AssociatePublicIpAddress": {
               "Fn::If": [
                 "AssignPublicIp",
-                "true",
-                "false"
+                true,
+                false
               ]
             },
             "DeviceIndex": "0",

--- a/Templates/make_artifactory-PRO_RDS.tmplt.json
+++ b/Templates/make_artifactory-PRO_RDS.tmplt.json
@@ -50,7 +50,6 @@
             "DbDataSize",
             "DbStorageType",
             "DbStorageIops",
-            "TargetVPC",
             "DbSubnets",
             "DbSecurityGroup"
           ]
@@ -201,11 +200,6 @@
       "Default": "9.6.10",
       "Description": "The X.Y.Z version of the PostGreSQL database to deploy.",
       "Type": "String"
-    },
-    "TargetVPC": {
-      "AllowedPattern": "^vpc-[0-9a-f]*$",
-      "Description": "ID of the VPC to deploy cluster nodes into.",
-      "Type": "AWS::EC2::VPC::Id"
     }
   },
   "Resources": {
@@ -213,8 +207,8 @@
       "Metadata": {},
       "Properties": {
         "AllocatedStorage": { "Ref": "DbDataSize" },
-        "AllowMajorVersionUpgrade": "true",
-        "AutoMinorVersionUpgrade": "true",
+        "AllowMajorVersionUpgrade": true,
+        "AutoMinorVersionUpgrade": true,
         "BackupRetentionPeriod": "7",
         "DBInstanceClass": { "Ref": "DbInstanceType" },
         "DBInstanceIdentifier": {
@@ -260,7 +254,7 @@
         "MultiAZ": { "Ref": "DbIsMultiAz" },
         "PreferredBackupWindow": "23:30-00:00",
         "PreferredMaintenanceWindow": "sun:00:30-sun:01:00",
-        "PubliclyAccessible": "false",
+        "PubliclyAccessible": false,
         "StorageType": { "Ref": "DbStorageType" },
         "Tags": [
           {

--- a/Templates/make_artifactory-PRO_S3-buckets.tmplt.json
+++ b/Templates/make_artifactory-PRO_S3-buckets.tmplt.json
@@ -130,7 +130,7 @@
                   "Format": "CSV",
                   "Prefix": "StorageReporting/Inventory"
                 },
-                "Enabled": "true",
+                "Enabled": true,
                 "IncludedObjectVersions": "Current",
                 "Prefix": "Backups/",
                 "ScheduleFrequency": "Weekly"

--- a/Templates/make_artifactory-PRO_parent-EFS.tmplt.json
+++ b/Templates/make_artifactory-PRO_parent-EFS.tmplt.json
@@ -491,7 +491,6 @@
   },
   "Resources": {
     "Ec2Res": {
-      "DependsOn": "RdsRes",
       "Properties": {
         "Parameters": {
           "AdminPubkeyURL": { "Ref": "AdminPubkeyURL" },
@@ -586,7 +585,7 @@
           "ServiceTld": { "Ref": "ServiceTld" }
         },
         "TemplateURL": { "Ref": "EfsTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -618,12 +617,11 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "ElbTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
     "IamRes": {
-      "DependsOn": "S3Res",
       "Properties": {
         "Parameters": {
           "BackupBucketArn": {
@@ -632,12 +630,11 @@
           "RolePrefix": { "Ref": "RolePrefix" }
         },
         "TemplateURL": { "Ref": "IamTemplateUri" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
     "RdsRes": {
-      "DependsOn": "SgRes",
       "Properties": {
         "Parameters": {
           "DbAdminName": { "Ref": "DbAdminName" },
@@ -671,7 +668,7 @@
           "BackupBucket": { "Ref": "BackupBucket" }
         },
         "TemplateURL": { "Ref": "BucketTemplateUri" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -681,7 +678,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SgTemplateUri" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_artifactory-PRO_parent.tmplt.json
+++ b/Templates/make_artifactory-PRO_parent.tmplt.json
@@ -579,7 +579,6 @@
   },
   "Resources": {
     "Ec2Res": {
-      "DependsOn": "RdsRes",
       "Properties": {
         "Parameters": {
           "AdminPubkeyURL": { "Ref": "AdminPubkeyURL" },
@@ -681,12 +680,11 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "ElbTemplate" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
     "IamRes": {
-      "DependsOn": "S3Res",
       "Properties": {
         "Parameters": {
           "BackupBucketArn": {
@@ -695,12 +693,11 @@
           "RolePrefix": { "Ref": "RolePrefix" }
         },
         "TemplateURL": { "Ref": "IamTemplateUri" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
     "RdsRes": {
-      "DependsOn": "SgRes",
       "Properties": {
         "Parameters": {
           "DbAdminName": { "Ref": "DbAdminName" },
@@ -734,7 +731,7 @@
           "BackupBucket": { "Ref": "BackupBucket" }
         },
         "TemplateURL": { "Ref": "BucketTemplateUri" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -744,7 +741,7 @@
           "TargetVPC": { "Ref": "TargetVPC" }
         },
         "TemplateURL": { "Ref": "SgTemplateUri" },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }

--- a/Templates/make_artifactory_EC2-node.tmplt.json
+++ b/Templates/make_artifactory_EC2-node.tmplt.json
@@ -49,18 +49,6 @@
         }
       ]
     },
-    "Reboot": {
-      "Fn::Not": [
-        {
-          "Fn::Equals": [
-            {
-              "Ref": "NoReboot"
-            },
-            "true"
-          ]
-        }
-      ]
-    },
     "UseCfnUrl": {
       "Fn::Not": [
         {
@@ -107,8 +95,7 @@
             "Domainname",
             "SecurityGroupIds",
             "SubnetIds",
-            "NoPublicIp",
-            "NoReboot"
+            "NoPublicIp"
           ]
         },
         {
@@ -274,7 +261,7 @@
     "AmiId": {
       "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
       "Description": "ID of the AMI to launch",
-      "Type": "String"
+      "Type": "AWS::EC2::Image::Id"
     },
     "BackupVolumeDevice": {
       "AllowedValues": [
@@ -541,15 +528,6 @@
       "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
       "Type": "String"
     },
-    "NoReboot": {
-      "AllowedValues": [
-        "false",
-        "true"
-      ],
-      "Default": "false",
-      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
-      "Type": "String"
-    },
     "PipIndexFips": {
       "AllowedPattern": "^$|^http://.*$|^https://.*$",
       "Default": "https://pypi.org/simple/",
@@ -736,8 +714,8 @@
           {
             "DeviceName": "/dev/xvda",
             "Ebs": {
-              "DeleteOnTermination": "true",
-              "VolumeSize": "20",
+              "DeleteOnTermination": true,
+              "VolumeSize": 20,
               "VolumeType": "gp2"
             }
           },
@@ -749,7 +727,7 @@
                   "Ref": "AppVolumeDevice"
                 },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": {
                     "Ref": "AppVolumeSize"
                   },
@@ -771,7 +749,7 @@
                   "Ref": "BackupVolumeDevice"
                 },
                 "Ebs": {
-                  "DeleteOnTermination": "true",
+                  "DeleteOnTermination": true,
                   "VolumeSize": {
                     "Ref": "BackupVolumeSize"
                   },
@@ -811,8 +789,8 @@
             "AssociatePublicIpAddress": {
               "Fn::If": [
                 "AssignPublicIp",
-                "true",
-                "false"
+                true,
+                false
               ]
             },
             "DeviceIndex": "0",

--- a/Templates/make_artifactory_ELBv1.tmplt.json
+++ b/Templates/make_artifactory_ELBv1.tmplt.json
@@ -79,7 +79,7 @@
         "ConnectionSettings": {
           "IdleTimeout": { "Ref": "BackendTimeout" }
         },
-        "CrossZone": "true",
+        "CrossZone": true,
         "HealthCheck": {
           "HealthyThreshold": "5",
           "Interval": "30",

--- a/Templates/make_artifactory_ELBv2.tmplt.json
+++ b/Templates/make_artifactory_ELBv2.tmplt.json
@@ -36,13 +36,6 @@
     }
   },
   "Parameters": {
-    "BackendTimeout": {
-      "Default": "600",
-      "Description": "How long - in seconds - back-end connection may be idle before attempting session-cleanup",
-      "MinValue": "60",
-      "MaxValue": "3600",
-      "Type": "Number"
-    },
     "HaSubnets": {
       "Description": "Select three subnets - each from different Availability Zones.",
       "Type": "List<AWS::EC2::Subnet::Id>"
@@ -143,7 +136,7 @@
     "ArtifactoryPubAlbTgroup": {
       "Properties": {
         "HealthCheckPath": "/index.html",
-        "HealthyThresholdCount": "5",
+        "HealthyThresholdCount": 5,
         "Name": {
           "Fn::Join": [
             "-",
@@ -173,7 +166,7 @@
             "Port": { "Ref": "ArtifactoryServicePort" }
           }
         ],
-        "UnhealthyThresholdCount": "2",
+        "UnhealthyThresholdCount": 2,
         "VpcId": { "Ref": "TargetVPC" }
       },
       "Type" : "AWS::ElasticLoadBalancingV2::TargetGroup"

--- a/Templates/make_artifactory_RDS-pgsql.tmplt.json
+++ b/Templates/make_artifactory_RDS-pgsql.tmplt.json
@@ -126,10 +126,6 @@
       "Default": "9.6.10",
       "Description": "The X.Y.Z version of PostGreSQL to use.",
       "Type": "String"
-    },
-    "VpcId": {
-      "Description": "ID of an existing Virtual Private Cloud (VPC).",
-      "Type": "AWS::EC2::VPC::Id"
     }
   },
   "Resources": {
@@ -137,8 +133,8 @@
       "Metadata": {},
       "Properties": {
         "AllocatedStorage": { "Ref": "DbStorageSize" },
-        "AllowMajorVersionUpgrade": "true",
-        "AutoMinorVersionUpgrade": "true",
+        "AllowMajorVersionUpgrade": true,
+        "AutoMinorVersionUpgrade": true,
         "BackupRetentionPeriod": "7",
         "DBInstanceClass": { "Ref": "DBInstanceClass" },
         "DBInstanceIdentifier": {

--- a/Templates/make_artifactory_SGs.tmplt.json
+++ b/Templates/make_artifactory_SGs.tmplt.json
@@ -21,7 +21,7 @@
     "TargetVPC": {
       "AllowedPattern": "^vpc-[0-9a-f]*$",
       "Description": "ID of the VPC to deploy cluster nodes into.",
-      "Type": "String"
+      "Type": "AWS::EC2::VPC::Id"
     }
   },
   "Resources": {
@@ -34,14 +34,13 @@
       }
     },
     "UpdateRdsSg": {
-      "DependsOn": "RdsSg",
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": { "Ref": "RdsSg" },
         "SourceSecurityGroupId": { "Ref": "RdsSg" },
         "IpProtocol": "tcp",
-        "FromPort": "5432",
-        "ToPort": "5432"
+        "FromPort": 5432,
+        "ToPort": 5432
       }
     },
     "NasSg": {
@@ -53,14 +52,13 @@
       }
     },
     "UpdateNasSg": {
-      "DependsOn": "NasSg",
       "Type": "AWS::EC2::SecurityGroupIngress",
       "Properties": {
         "GroupId": { "Ref": "NasSg" },
         "SourceSecurityGroupId": { "Ref": "NasSg" },
         "IpProtocol": "tcp",
-        "FromPort": "0",
-        "ToPort": "65535"
+        "FromPort": 0,
+        "ToPort": 65535
       }
     },
     "AppSg": {
@@ -70,20 +68,20 @@
         "SecurityGroupIngress": [
           {
             "IpProtocol": "tcp",
-            "FromPort": "8081",
-            "ToPort": "8081",
+            "FromPort": 8081,
+            "ToPort": 8081,
             "CidrIp": "0.0.0.0/0"
           },
           {
             "IpProtocol": "tcp",
-            "FromPort": "80",
-            "ToPort": "80",
+            "FromPort": 80,
+            "ToPort": 80,
             "CidrIp": "0.0.0.0/0"
           },
           {
             "IpProtocol": "tcp",
-            "FromPort": "443",
-            "ToPort": "443",
+            "FromPort": 443,
+            "ToPort": 443,
             "CidrIp": "0.0.0.0/0"
           }
         ],

--- a/Templates/make_artifactory_parent.tmplt.json
+++ b/Templates/make_artifactory_parent.tmplt.json
@@ -22,8 +22,7 @@
             "ArtifactoryOsPrepScriptUrl",
             "ArtifactoryDbPropsScriptUrl",
             "ArtifactoryStorageScriptUrl",
-            "ArtifactoryHaSetupScriptUrl",
-            "ArtifactoryBkupScriptUrl"
+            "ArtifactoryHaSetupScriptUrl"
           ]
         },
         {
@@ -116,9 +115,6 @@
         },
         "AppVolumeSize": {
           "default": "Artifactory Cache Size"
-        },
-        "ArtifactoryBkupScriptUrl": {
-          "default": "Backup script URL"
         },
         "ArtifactoryDbAdmin": {
           "default": "Master database administrator"
@@ -243,11 +239,6 @@
       ],
       "Default": "gp2",
       "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-      "Type": "String"
-    },
-    "ArtifactoryBkupScriptUrl": {
-      "AllowedPattern": "^$|^http://.*$|^https://.*$",
-      "Description": "Cron-script for moving Artifactory backups to S3",
       "Type": "String"
     },
     "ArtifactBucket": {
@@ -670,7 +661,7 @@
         "TemplateURL": {
           "Ref": "ArtifactoryHostTemplate"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -684,7 +675,7 @@
         "TemplateURL": {
           "Ref": "BucketIamTemplate"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     },
@@ -698,7 +689,7 @@
         "TemplateURL": {
           "Ref": "ArtifactBucketTemplate"
         },
-        "TimeoutInMinutes": "10"
+        "TimeoutInMinutes": 10
       },
       "Type": "AWS::CloudFormation::Stack"
     }


### PR DESCRIPTION
#### Description:

Adds [cfn-python-lint](https://github.com/awslabs/cfn-python-lint) to validation test-set

#### Rationale:

Adding cfn-python-lint to test-set better ensure thats CFn templates are _fucntional_ &mdash; in addition to simply being valid JSON (as performed by previously-existing `jq`-based test)

#### Additional

- Lint the templates already in project so that new test will pass.
- Reorganize `.travis.yml` content